### PR TITLE
[XI-6068] Controls show a current time of 'NaN' while seeking

### DIFF
--- a/src/components/player/player.tsx
+++ b/src/components/player/player.tsx
@@ -15,11 +15,7 @@ import { Mode, Status, defaultStatus } from '../../utils/status';
 import { TextTrackList, WebVTT } from '../../utils/webVTT';
 import { bind } from '../../utils/bind';
 import { isKnownLocale } from '../../utils/locales';
-import {
-  ToggleControlProps,
-  CueListChangeEventProps,
-  VimeoSeekedDetail,
-} from '../../utils/types';
+import { ToggleControlProps, CueListChangeEventProps } from '../../utils/types';
 import {
   exitFullscreen,
   fixDecimalPrecision,
@@ -286,24 +282,6 @@ export class Player {
     }
   }
 
-  /**
-   * Listen to a Vimeo event 'seeked' that returns updated progress.
-   * Triggered when the player seeks to a specific time. A timeupdate event will also be fired at the same time
-   * then update the status accordingly
-   */
-  @Listen('seeked')
-  private handleSeeked(e: CustomEvent<VimeoSeekedDetail>) {
-    const { seconds, percent } = e.detail;
-    this.status = {
-      ...this.status,
-      progress: {
-        seconds,
-        percent,
-      },
-    };
-    this.cueUpdate(seconds);
-  }
-
   @bind()
   @Listen('toggleControl:loaded')
   protected _addToggleControlButton(e: CustomEvent<ToggleControlProps>) {
@@ -434,6 +412,11 @@ export class Player {
 
     if (this.status.mode === Mode.PAUSED) {
       this.pause();
+      this.status = {
+        ...this.status,
+        progress: { ...this.status.progress, seconds },
+      };
+      this.cueUpdate(seconds);
     }
   }
 

--- a/src/utils/types.d.ts
+++ b/src/utils/types.d.ts
@@ -9,9 +9,3 @@ export interface ToggleControlProps {
   title: string;
   active: boolean;
 }
-
-export interface VimeoSeekedDetail {
-  duration: number;
-  seconds: number;
-  percent: number;
-}


### PR DESCRIPTION
## What does this change?
This PR fixes the controls of Kaltura players showing a current time of `NaN` while seeking.

The payload of the `'seeked'` event is undefined in the Kaltura API. 
This caused the current time of the player to be `NaN` for a short period of time since `this.status.progress.seconds` was being updated with a value of `undefined`. Right after that, the `'timeupdate'` event was fired and the current time was restored.

| before      | after |
| ----------- | ----------- |
| <img width="884" alt="bf" src="https://user-images.githubusercontent.com/62883011/232005854-6b7f44e2-ca62-4f0f-b280-eb8cf232c6f8.png"> | <img width="884" alt="af" src="https://user-images.githubusercontent.com/62883011/232005975-f5252676-05a6-4bc1-81f7-886b92526c3d.png"> |

## Decisions / Choices I made

Moving the update of the seconds from the `'seeked'` event listener to the `seek` method solves the issue.
For the same reason, seeking through the transcript was also broken for Kaltura videos ([see here](https://open.sap.com/courses/sf7-1/items/28mNQ0IoZPZ64830BmsKy2)). The `seconds` sent to `cueUpdate` were `undefined`. 

## Release Notes
```[Bugfix] Video player controls from Kaltura provider display a current time of 'NaN' while seeking (XI-6068)```